### PR TITLE
Added prefix option for dynamic queues

### DIFF
--- a/Tapeti.Annotations/DynamicQueueAttribute.cs
+++ b/Tapeti.Annotations/DynamicQueueAttribute.cs
@@ -9,5 +9,18 @@ namespace Tapeti.Annotations
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
     public class DynamicQueueAttribute : Attribute
     {
+        public string Prefix { get; set; }
+
+
+        /// <summary>
+        /// If prefix is specified, Tapeti will compose the queue name using the
+        /// prefix and a unique ID. If not specified, an empty queue name will be passed
+        /// to RabbitMQ thus letting it create a unique queue name.
+        /// </summary>
+        /// <param name="prefix"></param>
+        public DynamicQueueAttribute(string prefix = null)
+        {
+            Prefix = prefix;
+        }
     }
 }

--- a/Tapeti/Connection/TapetiWorker.cs
+++ b/Tapeti/Connection/TapetiWorker.cs
@@ -70,7 +70,7 @@ namespace Tapeti.Connection
 
                 if (queue.Dynamic)
                 {
-                    var dynamicQueue = channel.QueueDeclare();
+                    var dynamicQueue = channel.QueueDeclare(queue.Name);
                     (queue as IDynamicQueue)?.SetName(dynamicQueue.QueueName);
 
                     foreach (var binding in queue.Bindings)

--- a/Test/MarcoController.cs
+++ b/Test/MarcoController.cs
@@ -134,6 +134,7 @@ namespace Test
 
 
 
+        [DynamicQueue("custom.prefix")]
         public void Polo(PoloMessage message)
         {
             Console.WriteLine(">> Polo");


### PR DESCRIPTION
@HansMulder ik had het idee er een strategy van te maken (hence de naam van de branch), maar het zat iets meer in de core dan ik dacht. Volgens mij is het wel clean opgelost zo, als je een prefix meegeeft aan de attribute dan wordt de queue naam "prefix.GUID". Heb ook een uitleg erbij gezet in de comments hoe de Build method werkt en waarom.